### PR TITLE
Improving text email footer. Fixing unsubscribe instructions

### DIFF
--- a/gs/group/list/email/text/browser/templates/footer.pt
+++ b/gs/group/list/email/text/browser/templates/footer.pt
@@ -2,9 +2,17 @@
   xmlns:tal="http://xml.zope.org/namespaces/tal"
   xmlns:i18n="http://xml.zope.org/namespaces/i18n"
   i18n:domain="gs.group.list.email.text">
-――
+_______________________________________________
 <tal:block
-  i18n:translate="appendix-footer-topic">View topic <tal:block i18n:name="topicLink" replace="view/topicLink">http://groups.example.com/r/topic/2wzK5sNxM52OPbGlwSrH82</tal:block></tal:block>
+  i18n:translate="appendix-footer-address">Email group at <tal:block i18n:name="emailAddress" replace="view/groupEmail">group@groups.example.com</tal:block></tal:block>
 <tal:block
-  i18n:translate="appendix-footer-leave">Leave group <tal:block i18n:name="leaveLink" replace="view/leaveLink">mailto:group@groups.example.com?Subject=unsubscribe</tal:block></tal:block>
+  i18n:translate="appendix-footer-topic">View topic: <tal:block i18n:name="topicLink" replace="view/topicLink">http://groups.example.com/r/topic/2wzK5sNxM52OPbGlwSrH82</tal:block></tal:block>
+<tal:block
+  i18n:translate="appendix-footer-group">View group "<tal:block i18n:name="groupName" replace="view/groupName">Example Group</tal:block>": <tal:block i18n:name="groupLink" replace="view/groupLink">http://groups.example.com/groups/examplegroup</tal:block></tal:block>
+<tal:block
+  i18n:translate="appendix-footer-leave-link">Unsubscribe: <tal:block i18n:name="leaveLink" replace="view/leaveLink">http://groups.example.com/groups/leave.html?groupId=examplegroup</tal:block></tal:block>
+<tal:block
+  i18n:translate="appendix-footer-leave-email">Or to unsubscribe email <tal:block i18n:name="leaveEmail" replace="view/groupEmail">group@groups.example.com</tal:block> with subject "Unsubscribe"</tal:block>
+<tal:block
+  i18n:translate="appendix-footer-policies">List policies: <tal:block i18n:name="policyLink" replace="view/policyLink">http://groups.example.com/policies</tal:block></tal:block>
 </tal:block>

--- a/gs/group/list/email/text/footer.py
+++ b/gs/group/list/email/text/footer.py
@@ -29,8 +29,34 @@ class Footer(EmailMessageViewlet):
 
     @Lazy
     def leaveLink(self):
-        '''The leave link. Some cut-n-paste software engineering from
-``gs.group.list.sender.headers.simpleadd.ListUnsubscribe``'''
+        'The link to unsubscribe on the web'
+        r = '{siteUrl}/groups/leave.html?groupId={groupId}'
+        retval = r.format(siteUrl=self.siteInfo.url,
+                          groupId=self.groupInfo.id)
+        return retval
+
+    @Lazy
+    def groupName(self):
+        'Group name'
+        retval = self.groupInfo.name;
+        return retval
+
+    @Lazy
+    def groupEmail(self):
+        '''The group email address'''
         emailAddr = self.listInfo.get_property('mailto')
-        retval = 'mailto:{0}?subject=Unsubscribe'.format(emailAddr)
+        retval = emailAddr
+        return retval
+
+    @Lazy
+    def groupLink(self):
+        'The link to the group on the web'
+        retval = self.groupInfo.url;
+        return retval
+
+    @Lazy
+    def policyLink(self):
+        'The link to the policies on the web'
+        r = '{siteUrl}/policies'
+        retval = r.format(siteUrl=self.siteInfo.url)
         return retval


### PR DESCRIPTION
The email footer currently gives a unsubscribe link of "mailto:{listaddress}?subject=Unsubscribe". This doesn't actually link in the the email client (at least in gmail), only the email address does, so the user on clicking just opens an email window with the group address as the from address. Changed to instead give both a web link and instructions on how to unsub by email.

Also added links to the group and the policies. Not sure whether you'll want that in the main code, but at least having the functions to retrieve them would be appreciated.